### PR TITLE
Patch the mail of the new user

### DIFF
--- a/login/createuser.php
+++ b/login/createuser.php
@@ -7,18 +7,19 @@ include_once 'config.php';
 //Pull username, generate new ID and hash password
 $newid = uniqid(rand(), false);
 $newuser = $_POST['newuser'];
+$newemail = $_POST['email'];
 $newpw = password_hash($_POST['password1'], PASSWORD_DEFAULT);
 $pw1 = $_POST['password1'];
 $pw2 = $_POST['password2'];
 
-    //Enables moderator verification (overrides user self-verification emails)
+//Enables moderator verification (overrides user self-verification emails)
 if (isset($admin_email)) {
 
-    $newemail = $admin_email;
+    $activationemail = $admin_email;
 
 } else {
 
-    $newemail = $_POST['email'];
+    $activationemail = $_POST['email'];
 
 }
 //Validation rules
@@ -51,7 +52,7 @@ if ($pw1 != $pw2) {
 
             //Send verification email
             $m = new MailSender;
-            $m->sendMail($newemail, $newuser, $newid, 'Verify');
+            $m->sendMail($activationemail, $newuser, $newid, 'Verify');
 
         } else {
             //Failure

--- a/login/createuser.php
+++ b/login/createuser.php
@@ -19,7 +19,7 @@ if (isset($admin_email)) {
 
 } else {
 
-    $activationemail = $_POST['email'];
+    $activationemail = $newemail;
 
 }
 //Validation rules


### PR DESCRIPTION
If the `$admin_email` is set (if you want a moderator to verify users and not the users themselves) there is a little bug:
Each new user have `$admin_email` so:
- Each user have the same mail
- You can't have more then 1 user (mail check for duplicate entry fails)
- The user email is wrong

After this patch:
Each user have their own mail, but the verification email is sent to `$admin_email` (if it set, otherwise is sent to User mail).